### PR TITLE
Update theme styling

### DIFF
--- a/main.less
+++ b/main.less
@@ -61,6 +61,7 @@
 .CodeMirror .cm-rangeinfo { color: @aqua; }
 .CodeMirror .cm-minus { color: @red; }
 .CodeMirror .cm-plus { color: @green; }
+.CodeMirror .cm-matchhighlight { border-bottom-color: @foreground; }
 
 .CodeMirror,
 .CodeMirror .CodeMirror-scroll {

--- a/main.less
+++ b/main.less
@@ -81,6 +81,15 @@
     background-color: @selection-color-focused;
 }
 
+.CodeMirror-nonmatchingbracket {
+    background-color: fadeout(@red, 20%);
+    color: lighten(@white, 10%);
+}
+
+.CodeMirror-focused .CodeMirror-nonmatchingbracket {
+    background-color: @red;
+}
+
 .CodeMirror-matchingbracket {
     background-color: fadeout(@matching-bracket, 10%);
     color: lighten(@white, 10%) !important;

--- a/main.less
+++ b/main.less
@@ -7,11 +7,11 @@
  */
 
 
-/* Overall Colors */
+/* Palette */
 @background: #1d1f21;
-@current-line: #282a2e;
 @foreground: #c5c8c6;
 @comment: #969896;
+@white: #e1e5e2;
 @orange: #de935f;
 @blue: #81a2be;
 @purple: #b294bb;
@@ -21,13 +21,20 @@
 @yellow: #f0c674;
 
 /* Selection colors */
-@selection-color-focused: rgba(0, 121, 160, 0.31);
-@selection-color-unfocused: #424242;
+@selection-color-focused: fade(@blue, 32%);
+@selection-color-unfocused: rgb(66, 66, 66);
 
-@activeline-bgcolor: rgba(96, 96, 96, 0.5);
-@activeline-number-bgcolor: rgba(96, 96, 96, 0.5);
-@matching-bracket: rgba(189, 100, 100, 0.8);
+/* Active line colors */
+@activeline-bgcolor: rgba(96, 96, 96, 0.4);
+@activeline-number-bgcolor: rgba(80, 80, 80, 0.3);
+@activeline-number-color: rgba(255, 255, 255, 0.8);
 
+/* Matching colors */
+@matching-bracket: fade(@foreground, 40%);
+@matching-tag: fade(@foreground, 20%);
+
+
+/* Editor styling */
 .CodeMirror .cm-keyword { color: @purple; }
 .CodeMirror .cm-atom { color: @orange; }
 .CodeMirror .cm-number { color: @green; }
@@ -43,7 +50,7 @@
 .CodeMirror .cm-meta { color: @red; }
 .CodeMirror .cm-error { color: @red; }
 .CodeMirror .cm-qualifier { color: @blue; }
-.CodeMirror .cm-builtin { color: @yellow; }
+.CodeMirror .cm-builtin { color: @red; }
 .CodeMirror .cm-bracket { color: @foreground; }
 .CodeMirror .cm-tag { color: @blue; }
 .CodeMirror .cm-attribute { color: @orange; }
@@ -61,44 +68,79 @@
     color: @foreground;
 }
 
-.CodeMirror .CodeMirror-selected {
-    background: @selection-color-unfocused;
-}
-.CodeMirror-focused .CodeMirror-selected {
-    background: @selection-color-focused;
-}
-
-.CodeMirror .CodeMirror-gutters {
+.CodeMirror-gutters {
     background-color: @background;
-    border-right: 1px solid #696969;
 }
 
-.CodeMirror-activeline .CodeMirror-gutter-elt {
-    color: @foreground !important;
+.CodeMirror-selected {
+    background-color: @selection-color-unfocused;
+}
+
+.CodeMirror-focused .CodeMirror-selected {
+    background-color: @selection-color-focused;
+}
+
+.CodeMirror-matchingbracket {
+    background-color: fadeout(@matching-bracket, 10%);
+    color: lighten(@white, 10%) !important;
+}
+
+.CodeMirror-focused .CodeMirror-matchingbracket {
+    background-color: @matching-bracket;
+}
+
+.CodeMirror-matchingtag {
+    background-color: fadeout(@matching-tag, 10%);
+}
+
+.CodeMirror-focused .CodeMirror-matchingtag {
+    background-color: @matching-tag;
 }
 
 .CodeMirror-gutter-elt {
     color: @comment !important;
 }
 
-.CodeMirror-selected {
-    background: rgba(173, 107, 107, 0.39);
-}
-
-.CodeMirror .CodeMirror-matchingbracket {
-    color: @foreground !important;
-    background-color: @matching-bracket;
-}
-
-.CodeMirror .CodeMirror-linenumber {
-    color: @activeline-number-bgcolor;
-}
-
-.CodeMirror-activeline-background,
 .CodeMirror-activeline .CodeMirror-gutter-elt {
-    background: @activeline-bgcolor !important;
+    color: @foreground !important;
+}
+
+.CodeMirror-activeline .CodeMirror-linenumber {
+    color: @activeline-number-color !important;
+}
+
+.CodeMirror-activeline-background {
+    background-color: fadeout(@activeline-bgcolor, 15%) !important;
+}
+
+.CodeMirror-focused .CodeMirror-activeline-background {
+    background-color: @activeline-bgcolor !important;
+}
+
+.CodeMirror-activeline .CodeMirror-gutter-elt {
+    background-color: fadeout(@activeline-number-bgcolor, 15%) !important;
+}
+
+.CodeMirror-focused .CodeMirror-activeline .CodeMirror-gutter-elt {
+    background-color: @activeline-number-bgcolor !important;
 }
 
 .CodeMirror-cursor {
-    border-left: 1px solid @foreground !important;
+    border-left: 1px solid @white !important;
+}
+
+.CodeMirror-overwrite .CodeMirror-cursor {
+    border-bottom: 1px solid @white;
+    border-left: none !important;
+}
+
+
+/* Non-editor styling */
+#not-editor,
+#image-holder {
+    background-color: @background;
+}
+
+#image-holder {
+    color: @foreground;
 }


### PR DESCRIPTION
This is a follow-up to issue #2.
#### Summary of changes
- added basic non-editor and image viewer styling
- added overwrite cursor styling
- added matching tag styling
- changed selection color
- changed active line colors
- changed cm-builtin color (helps distinguish CSS ids from classes)
- removed gutter border
- window focus improvements

I've only tested these changes with the current master (0.43) on Windows. Feel free to merge as much or little as you want.
